### PR TITLE
Add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+Please note this is a bug tracker, not a support forum. After you have read the [Submitting useful bug reports guide](https://github.com/WhisperSystems/Signal-Android/wiki/Submitting-useful-bug-reports), delete this line. Also delete any sections that aren't applicable.
+
+### Bug description
+
+### Steps to reproduce
+
+### Screenshots
+
+### Device info
+ **Model:** 
+ 
+ **Android version:** 
+ 
+ **Signal version:** 
+ 
+### App state
+
+### Link to debug log


### PR DESCRIPTION
As documented here: https://help.github.com/articles/creating-an-issue-template-for-your-repository/
Github has new issue template functionality. Loosely on the wiki page linked within the template.

// FREEBIE
